### PR TITLE
using unix posix instead of dfs_posix

### DIFF
--- a/src/fdt_load.c
+++ b/src/fdt_load.c
@@ -1,5 +1,6 @@
 #include <rthw.h>
-#include <dfs_posix.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include "libfdt/libfdt.h"
 #include "fdt.h"


### PR DESCRIPTION
项目中IO相关操作的头文件改成posix标准头文件而不是dfs_posix，提高兼容性